### PR TITLE
Allow use when jQuery is running in No Conflict mode

### DIFF
--- a/js/jQuery.customInput.js
+++ b/js/jQuery.customInput.js
@@ -6,7 +6,10 @@
  * licensed under MIT (filamentgroup.com/examples/mit-license.txt)
  * --------------------------------------------------------------------
  */
-jQuery.fn.customInput = function(){
+
+(function ($) {
+
+$.fn.customInput = function(){
 	return $(this).each(function(){	
 		if($(this).is('[type=checkbox],[type=radio]')){
 			var input = $(this);
@@ -39,6 +42,8 @@ jQuery.fn.customInput = function(){
 		}
 	});
 };
+
+}(jQuery));
 
 
 	


### PR DESCRIPTION
Currently, the library can't be used when jQuery is running in [No Conflic'](http://api.jquery.com/jQuery.noConflict/) mode, as `$` is referenced from the global scope.

I've wrapped the code up in an anonymous function so `$` always contains `jQuery`.

Just as a note, I ran into this when using the library on a Magento site, where Prototype is included as well as jQuery. 
