### PR TITLE
Resolves a conflict when multiple labels applies to the same input

### DIFF
--- a/js/jQuery.customInput.js
+++ b/js/jQuery.customInput.js
@@ -15,7 +15,10 @@
 				var input = $(this);
 				
 				// get the associated label using the input's id
-				var label = $('label[for="'+input.attr('id')+'"]');
+				var label = input.siblings('label[for="'+input.attr('id')+'"]:first');
+				if (!label.length) {
+          				label = input.closest('label[for="'+input.attr('id')+'"]:first');
+		 		}
 				
 				// wrap the input + label in a div 
 				input.add(label).wrapAll('<div class="custom-'+ input.attr('type') +'"></div>');


### PR DESCRIPTION
When multiple labels are applied to the same input, the plugin applies the styling on all labels which results in duplicate inputs. 
This fix attempts to find the correct label.
